### PR TITLE
New runtime architecture for test grading and split out one file

### DIFF
--- a/defs.rkt
+++ b/defs.rkt
@@ -54,3 +54,12 @@
 ;(define list-abbreviation-enabled (make-parameter #f))
 (define verbose-error-logging?  (make-parameter #t))
 
+
+(struct exn:fail:student-error    exn:fail:user ())         ;student errors like missing tags
+(struct exn:fail:ensure-violation exn:fail:user ())         ;student errors like changing tests or signatures
+(struct exn:fail:eval-error       exn:fail:user (student?)) ;error evaluating teaching language code student? false if grader code
+
+
+(define (raise-student-error msg . v)
+  (raise (exn:fail:student-error  (apply format msg v) (current-continuation-marks))))
+

--- a/file-structure.rkt
+++ b/file-structure.rkt
@@ -1,0 +1,220 @@
+#lang racket
+
+(require "defs.rkt"
+         "utils.rkt")
+
+(provide (all-defined-out))
+
+(struct elt (tags sexp) #:transparent)
+
+(define CHECK-FORMS
+  '(check-expect check-random check-satisfied check-within check-error check-member-of check-range))
+
+
+
+(define (tag-sexps t)
+  (map elt-sexp (filter (compose (curry member t) elt-tags) (elts))))
+
+
+(define (get-problem* n)
+  (or (get-by-pred (lambda (x) (and (@problem? x) (= n (problem-num x)))))
+      (raise-student-error  "Could not find (@problem ~a)." n)))
+
+
+
+(define (get-htdf* n) (get-by-name-or-index '@htdf @htdf? n (lambda (x) (member n (htdf-names x)))))
+(define (get-htdd* n) (get-by-name-or-index '@htdd @htdd? n (lambda (x) (member n (htdd-names x)))))
+(define (get-htdw* n) (get-by-name-or-index '@htdw @htdw? n (lambda (x) (eqv? n (htdw-ws x)))))
+
+(define (get-by-name-or-index kind type? n name?)
+  (cond [(and (symbol? n)
+	      (eqv? #\$ (string-ref (symbol->string n) 0)))
+	 (or (get-by-pred type?)
+	     (raise-student-error "could not find ~a tag." kind))]
+	[(symbol? n)
+	 (or (get-by-pred (lambda (x) (and (type? x) (name? x))))
+	     (raise-student-error "could not find (~a ~a)." kind n))]
+	[(number? n)
+	 (or (get-by-index type? n)
+	     (raise-student-error "could not find ~a number ~a" kind n))]))
+
+(define (get-by-pred p)
+  (let loop ([sexps (if (null? (context)) (map elt-sexp (elts)) (tag-sexps (car (context))))])
+    (cond [(empty? sexps) #f]
+          [(p (car sexps)) (car sexps)]
+          [else
+           (loop (rest sexps))])))
+
+(define (get-by-index p n)
+  (let loop ([i 0]                        ;!!! below was just (elts)
+	     [sexps (if (null? (context)) (map elt-sexp (elts)) (tag-sexps (car (context))))])
+    (cond [(empty? sexps)                 #f]
+	  [(and (p (car sexps)) (= i n))  (car sexps)]
+	  [     (p (car sexps))           (loop (add1 i) (rest sexps))]
+	  [else                           (loop       i  (rest sexps))])))
+
+(define (get-all-tests)
+  (filter check? (map elt-sexp (elts))))
+
+(define (get-function-tests fn-name)
+  (filter (lambda (t)
+	    (and (check? t)
+		 (let ([test-actual (cadr t)])
+		   (and (pair? test-actual)
+			(or (eqv? (car test-actual) fn-name)
+			    (and (eqv? (car test-actual) 'local)
+				 (eqv? (caaddr test-actual) fn-name)))))))
+	  (map elt-sexp (elts))))
+
+
+
+
+
+(define (fn->elts fn)
+  (parse-elts (read-sexps fn)))
+
+(define (read-sexps fn)
+  (call-with-input-file fn
+    (lambda (p)
+      (parameterize ([read-accept-reader #t]
+		     [read-case-sensitive #t]
+                     [read-decimal-as-inexact #f] ;to match teaching languages
+		     [current-input-port p])
+	(read-line (current-input-port))
+	(read-line (current-input-port))
+	(read-line (current-input-port))
+	
+	(let loop ([se (read)])
+	  (if (eof-object? se)
+	      '()
+	      (cons (post-read-convert se) (loop (read)))))))))
+
+(define (read-syntaxes fn)
+  (call-with-input-file fn
+    (lambda (p)
+      (parameterize ([read-accept-reader #t]
+		     [read-case-sensitive #t]
+                     [read-decimal-as-inexact #f] ;to match teaching languages
+		     [current-input-port p])
+
+        (cdr (syntax->list (cadddr (syntax->list (read-syntax fn p)))))))))
+  
+
+
+
+
+(define (parse-elts lose)
+  ;;
+  ;; The grade-xxx forms enforce a nesting of graders as follows
+  ;;  grade-problem (must be at top-level)
+  ;;   grade-htdd
+  ;;     grade-dd-rules-and-template
+  ;;     ...
+  ;;   grade-htdf
+  ;;     grade-signature
+  ;;     grade-tests-validity
+  ;;     ...
+  ;;
+  ;; So we parse the appearance of tags in the file as matching that structure.
+  ;;
+  (define (clear-context @t context)
+    (cond [(eq? @t    '@problem)      (remove-all '(@problem @htdf @htdd) context)]
+          [(member @t '(@htdd @htdf)) (remove-all '(@htdd @htdf) context)]
+          [(eq? @t    '@htdw)         (remove-all '(@htdw) context)]))
+
+  (define (remove-all tags context)
+    (cond [(null? context) context]
+          [else
+           (if (and (pair? (car context))
+                    (member (caar context) tags))
+               (remove-all tags (cdr context))
+               (cons (car context)
+                     (remove-all tags (cdr context))))]))
+           
+
+  (let loop ([lose lose]
+	     [context '()])
+    (if (null? lose)
+	'()
+	(let ([sexp (first lose)])
+	  (cond [(and (pair? sexp)
+		      (member (first sexp) '(@problem @htdw @htdd @htdf)))
+		 (let ([new-context (cons sexp (clear-context (first sexp) context))])
+		   (cons (elt (cdr new-context) sexp)
+			 (loop (cdr lose)
+			       new-context)))]
+                [(and (pair? sexp)
+                      (eqv? (first sexp) '@signature))
+                 (cons (elt context (subst 'false #f sexp)) ;!!! make this go away, false is a symbol in this case not a value
+                       (loop (cdr lose)
+                             context))]
+		[else
+		 (cons (elt context sexp)
+		       (loop (cdr lose)
+			     context))])))))
+
+
+
+(define problem-sexps tag-sexps)  ;some tags have elements after them
+(define htdw-sexps    tag-sexps)
+(define htdd-sexps    tag-sexps)
+(define htdf-sexps    tag-sexps)
+
+(define problem-num             cadr)    ;data in the actual tag
+(define htdw-ws                 cadr)   
+(define htdf-names              cdr)    
+(define htdd-names              cdr)
+(define template-origin-origins cdr)
+(define template-defn           cadr)
+(define dd-template-rules-rules cdr)
+
+;; !!! the remove '@signature is because sometimes this is called on the tag and
+;; !!! sometimes it is called on just the signature. sigh.
+(define (signature-args   sig) (takef (remove '@signature sig) (lambda (x) (not (eqv? x '->))))) ;!!!cdr added because sig includes @signature
+(define (signature-result sig) (cadr (member '-> sig)))
+(define (signature-fail?  sig) (equal? (cddr (member '-> sig)) '(or false)))
+
+(define (problem-htdfs         t) (filter @htdf?              (tag-sexps t)))
+
+(define (htdf-sigs             t) (filter @signature?         (tag-sexps t)))
+(define (htdf-checks           t) (filter check?              (tag-sexps t)))
+(define (htdf-template-origins t) (filter @template-origin?   (tag-sexps t)))
+(define (htdf-templates        t) (filter @template?          (tag-sexps t)))
+(define (htdf-defns            t) (filter fn-defn?            (tag-sexps t)))
+
+(define (htdd-constants        t) (filter const-defn?         (tag-sexps t)))
+(define (htdd-rules            t) (filter @dd-template-rules? (tag-sexps t)))
+(define (htdd-templates        t) (filter fn-defn?            (tag-sexps t)))
+
+
+(define (@assignment?          x) (and (pair? x) (eq? (car x) '@assignment)))
+(define (@cwl?                 x) (and (pair? x) (eq? (car x) '@cwl)))
+
+(define (@problem?             x) (and (pair? x) (eq? (car x) '@problem)))
+
+(define (@htdw?                x) (and (pair? x) (eq? (car x) '@htdw)))
+(define (@htdd?                x) (and (pair? x) (eq? (car x) '@htdd)))
+(define (@htdf?                x) (and (pair? x) (eq? (car x) '@htdf)))
+
+(define (@signature?           x) (and (pair? x) (eq? (car x) '@signature)))
+
+(define (@dd-template-rules?   x) (and (pair? x) (eq? (car x) '@dd-template-rules)))
+(define (@template-origin?     x) (and (pair? x) (eq? (car x) '@template-origin)))
+(define (@template?            x) (and (pair? x) (eq? (car x) '@template)))
+
+(define (require?              x) (and (pair? x) (eq?   (car x) 'require)))
+(define (fn-defn?              x) (and (pair? x) (eq? (car x) 'define) (pair? (cadr x)) (pair? (cddr x))))
+(define (const-defn?           x) (and (pair? x) (eq? (car x) 'define) (symbol? (cadr x))))
+(define (struct-defn?          x) (and (pair? x) (eq? (car x) 'define-struct)))
+(define (defn?                 x) (or (fn-defn? x) (const-defn? x) (struct-defn? x)))
+
+(define (check?                x) (and (pair? x) (member (car x) CHECK-FORMS)))
+(define (check-expect?         x) (and (pair? x) (eq? (car x) 'check-expect)))
+(define (not-check-satisfied?  x) (or (not (pair? x)) (not (eqv? (car x) 'check-satisfied))))
+
+(define fn-defn-name       caadr)
+(define fn-defn-parameters cdadr)
+(define fn-defn-body       caddr)
+
+
+

--- a/tonka.rkt
+++ b/tonka.rkt
@@ -1,9 +1,15 @@
 #lang racket/base
 
-(provide %%eval-tests
-         %%eval-test-args-and-results
-         %%check-validity
-         %%check-thoroughness)
+(require racket/function)
+
+(provide %%check-validity
+         %%check-argument-thoroughness
+         %%check-faulty-functions
+
+         %%call-thunks-with-handler
+         
+         %%equal-sets?
+         %%check-random)
 
 
 ;;
@@ -12,47 +18,28 @@
 ;; an observable effect on performance, but even if not, it's a plus in terms of
 ;; simplifying the runtime architecture of the grader.
 ;;
-
-;; (listof (_ -> (listof Any))) -> (listof (listof Any)|'error)
-(define (%%eval-tests thunks)
-  (for/list ([thunk thunks])
-    (with-handlers ([exn:fail? (lambda (e) 'error)])
-      (thunk (void)))))
+;; Note the generated code in the runtime architecture has to run in BSL, so we
+;; are it is not allowed to define zero-argument functions, and it is not allowed
+;; to use lambda.
+;;
 
 
-;; (listof (_ -> (listof Any))) -> (listof (listof Any)|'error)
-(define (%%eval-test-args-and-results thunks)
-  (for/list ([thunk thunks])
-    (with-handlers ([exn:fail? (lambda (e) 'error)])
-      (thunk (void)))))
-
-;; produce uids (index numbers) of tests that fail at least once
-(define (%%check-validity lo-args-with-result checker-names checker-thunks)
-  (let loop ([lo-args-with-result lo-args-with-result]
-             [test-uid 0])
-    (cond [(null? lo-args-with-result) '()]
-          [else
-           (mergeq (check-validity-thunks (car lo-args-with-result) checker-names checker-thunks)
-                   (loop (cdr lo-args-with-result) (add1 test-uid)))])))
+;; produce (listof #t|#f|error) indicating whether each check is valid
+(define (%%check-validity aar-thunks all-criteria)
+  (for/list ([args-and-result (%%call-thunks-with-handler aar-thunks)])
+    (if (eqv? args-and-result 'error)
+        'error
+        (with-handlers ([exn:fail? (lambda (e) 'error)])
+          (apply all-criteria (append (car args-and-result) (cdr args-and-result)))))))
 
 ;; produce names of checks that are satisfied at least once
-(define (%%check-thoroughness lo-args aa-check-names pa-check-names aa-check-thunks pa-check-thunks)
+(define (%%check-argument-thoroughness lo-args aa-check-names pa-check-names aa-check-thunks pa-check-thunks)
   (mergeq (check-thoroughness-thunks (list lo-args) aa-check-names aa-check-thunks)
           (let loop ([lo-args lo-args])
             (cond [(null? lo-args) '()]
                   [else
                    (mergeq (check-thoroughness-thunks (car lo-args) pa-check-names pa-check-thunks)
                            (loop (cdr lo-args)))]))))
-
-
-(define (check-validity-thunks args-with-result test-uid thunks)
-  (let loop ([thunks thunks])
-    (cond [(null? thunks) '()]
-          [else
-           (if (not (apply (car thunks) args-with-result))
-               (cons-if-not-memq test-uid
-                                 (loop (cdr thunks)))
-               (loop (cdr thunks)))])))
 
 (define (check-thoroughness-thunks args names thunks)
   (let loop ([names names]
@@ -63,6 +50,37 @@
                (cons-if-not-memq (car names)
                                  (loop (cdr names) (cdr thunks)))
                (loop (cdr names) (cdr thunks)))])))
+
+(define (%%check-faulty-functions all-tests faulty-fns)
+  (for/list ([fn faulty-fns])
+    (with-handlers ([exn:fail? (lambda (e) 'error)])
+      (all-tests fn))))
+
+
+
+;; (listof (_ -> (listof Any))) -> (listof (listof Any)|'error)
+(define (%%call-thunks-with-handler thunks)
+  (for/list ([thunk thunks])
+    (with-handlers ([exn:fail? (lambda (e) 'error)])
+      (thunk (void)))))
+
+
+
+(define (%%equal-sets? s1 s2) 
+  (and (andmap (curryr member s2) s1)
+       (andmap (curryr member s1) s2)
+       #t))
+
+(define (%%check-random thunk1 thunk2)
+  (let ([rng (make-pseudo-random-generator)]
+        [k (modulo (current-milliseconds) (sub1 (expt 2 31)))])
+    (equal? (begin (current-pseudo-random-generator rng)
+                   (random-seed k)
+                   (thunk1 (void)))
+            (begin (current-pseudo-random-generator rng)
+                   (random-seed k)
+                   (thunk2 (void))))))
+
 
 
 


### PR DESCRIPTION

I just completed a significant re-engineering of the runtime architecture of the grading primitives that involve running all or part of test expressions:

- grade-submitted-tests
- grade-additional-tests
- grade-tests-validity
- grade-argument-thoroughness
- grade-thoroughness-by-faulty-functions

Key to the change is introducing some runtime support that is in the file tonka.rkt. That file gets automatically required into the sandbox when a handin file is loaded.  This means that instead of having to pass all of the code that needs to run over into the sandbox each time, the graders can generate less code and rely on the runtime more.

As an example, consider the check-expects for sum:
```
(check-expect (sum empty) 0)
(check-expect (sum (cons 1 (cons 2 (cons 3 empty)))) (+ 1 2 3 0))  
(check-expect (sum (cons 9.1 (cons 5.2 (cons 7 empty)))) (+ 9.1 5.2 7))
```
And this bit of the grader for sum
```
(grade-tests-validity (lon) r
  (list? lon)
  (andmap number? lon)
  (equal? r (foldr + 0 lon)))
```
The grade-validity sends the following code to the sandbox for evaluation:
```
(local [;; produce args and result for each test
        (define (check323806 _) (list (list empty) 1))
        (define (check323807 _)
          (list (list (cons 3 (cons 4 (cons 5 empty)))) (* 3 4 5 1)))

        ;; --> true if ALL criteria satisfied for one set of args
        (define (%%all-criteria lon r)
          (and (list? lon) (andmap number? lon) (equal? r (foldr * 1 lon))))]

  (%%check-validity (list check323806 check323807) %%all-criteria))
```
And then %%check-validity is:
```
(define (%%check-validity aar-thunks all-criteria)
  (for/list ([args-and-result (%%call-thunks-with-handler aar-thunks)])
    (if (eqv? args-and-result 'error)
        'error
        (with-handlers ([exn:fail? (lambda (e) 'error)])
          (apply all-criteria (append (car args-and-result) (cdr args-and-result)))))))
```
It took some time getting it all ironed out work, but it's all simpler and more consistent now.  Along the way I surfaced bugs in about half-a-dozen old graders!
